### PR TITLE
Update 3d building data links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 ![Screenshot of a web browser running the line of sight tool. The searched address is 31 Oliver Street and there are six lines of sight to nearby nodes shown on a map.](/image.png?raw=true "Screenshot")
 
-This tool uses the [NYC 3D Building Model](https://www1.nyc.gov/site/doitt/initiatives/3d-building.page) to check if a building has line of sight to nearby nodes. The data is from 2014, so results are not 100% accurate.
+This tool uses the [NYC 3D Building Model](https://www.nyc.gov/content/oti/pages/tools) to check if a building has line of sight to nearby nodes. The data is from 2014, so results are not 100% accurate.
 
 See [mesh-api](https://github.com/meshcenter/mesh-api#line-of-sight) for more info.

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -46,7 +46,7 @@ export default function Form(props) {
 					<a
 						target="_"
 						className="dark-blue no-underline"
-						href="https://www1.nyc.gov/site/doitt/initiatives/3d-building.page"
+						href="https://www.nyc.gov/content/oti/pages/tools"
 					>
 						NYC 3D Building Model
 					</a>{" "}

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -379,7 +379,7 @@ function Info({ address }) {
 				<a
 					target="_"
 					className="dark-blue no-underline"
-					href="https://www1.nyc.gov/site/doitt/initiatives/3d-building.page"
+					href="https://www.nyc.gov/content/oti/pages/tools"
 				>
 					NYC 3D Building Model
 				</a>{" "}


### PR DESCRIPTION
The link used is unfortunately outdated: https://web.archive.org/web/20220113000754/https://www1.nyc.gov/site/doitt/initiatives/3d-building.page

It was kind of hard to find what the current link is. The best appears to be here: https://www.nyc.gov/content/oti/pages/tools

Note, this seemed like the first link at first, but it is a different dataset: https://www.nyc.gov/site/planning/data-maps/open-data/dwn-nyc-3d-model-download.page